### PR TITLE
Zero bottom lim when linear scale

### DIFF
--- a/demesdraw/size_history.py
+++ b/demesdraw/size_history.py
@@ -204,7 +204,8 @@ def size_history(
     # Arrange the axes spines, ticks and labels.
 
     ax.set_xlim(1 if log_time else 0, inf_start_time)
-    # ax.set_ylim(1 if log_size else 0, None)
+    if not log_size:
+        ax.set_ylim(bottom=0)
 
     for spine in ax.spines.values():
         spine.set_zorder(z_top)


### PR DESCRIPTION
Can take or leave, but I like to have zero as the bottom y limit when plotting on a linear scale. Gives a more representative visualization of size changes.