### PR TITLE
Use a smaller epsilon than 1 for log_time.

### DIFF
--- a/demesdraw/size_history.py
+++ b/demesdraw/size_history.py
@@ -98,7 +98,7 @@ def size_history(
                 start_time = inf_start_time
             end_time = epoch.end_time
             if end_time == 0 and log_time:
-                end_time = 1
+                end_time = 1e-6
 
             if epoch.size_function == "constant":
                 x = np.array([start_time, end_time])
@@ -140,7 +140,7 @@ def size_history(
                     text_x = (start_time + end_time) / 2
                 if log_size:
                     text_y = np.exp(
-                        (np.log(1 + epoch.start_size) + np.log(1 + epoch.end_size)) / 2
+                        (np.log(epoch.start_size) + np.log(1e-6 + epoch.end_size)) / 2
                     )
                 else:
                     text_y = (epoch.start_size + epoch.end_size) / 2

--- a/demesdraw/tubes.py
+++ b/demesdraw/tubes.py
@@ -71,7 +71,7 @@ class Tube:
                 if log_time:
                     t = np.exp(
                         np.linspace(
-                            np.log(start_time), np.log(1 + end_time), num=num_points
+                            np.log(start_time), np.log(1e-6 + end_time), num=num_points
                         )
                     )
                 else:
@@ -468,7 +468,9 @@ def tubes(
         if np.isinf(start_time):
             start_time = inf_start_time
         if log_scale:
-            t = np.exp(rng.uniform(np.log(start_time), np.log(1 + migration.end_time)))
+            t = np.exp(
+                rng.uniform(np.log(start_time), np.log(1e-6 + migration.end_time))
+            )
         else:
             t = rng.uniform(start_time, migration.end_time)
         return t
@@ -526,7 +528,7 @@ def tubes(
                 tmid = np.exp(
                     (
                         np.log(tubes[deme_id].time[0])
-                        + np.log(1 + tubes[deme_id].time[-1])
+                        + np.log(1e-6 + tubes[deme_id].time[-1])
                     )
                     / 2
                 )


### PR DESCRIPTION
Stupid things still happen when you look at generations
between 0 and 1 on a log scale, but at least generations
1, 2 and 3 look sensible (e.g. defaults_deme_many_epochs_local.yaml).