### PR TITLE
Revert "Bump numpy from 1.19.5 to 1.22.0 in /requirements"

### DIFF
--- a/requirements/minimal.txt
+++ b/requirements/minimal.txt
@@ -4,5 +4,5 @@ demes==0.2.1
 matplotlib==3.3.4; python_version=='3.6'
 matplotlib==3.5.1; python_version>='3.7'
 numpy==1.19.5; python_version=='3.6'
-numpy==1.22.0; python_version=='3.7'
+numpy==1.21.5; python_version=='3.7'
 numpy==1.22.0; python_version>='3.8'


### PR DESCRIPTION
Reverts grahamgower/demesdraw#78

This patch is wrong. But I'm not testing on Python 3.7 anywhere, so CI passed anyway.